### PR TITLE
ci: pin macOS 26 runner + Xcode 26.2

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -152,11 +152,6 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '26.2'
-      - name: Set macOS deployment target
-        if: steps.run.outputs.should-run == 'true' && runner.os == 'macOS'
-        run: |
-          echo "MACOSX_DEPLOYMENT_TARGET=15.0" >> $GITHUB_ENV
-          echo "CMAKE_OSX_DEPLOYMENT_TARGET=15.0" >> $GITHUB_ENV
       - name: Install CUDA
         if: steps.run.outputs.should-run == 'true' && matrix.target == 'cuda' && matrix.cuda-version
         uses: ./.github/actions/setup-cuda

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -152,6 +152,11 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '26.2'
+      - name: Set macOS deployment target
+        if: steps.run.outputs.should-run == 'true' && runner.os == 'macOS'
+        run: |
+          echo "MACOSX_DEPLOYMENT_TARGET=15.0" >> $GITHUB_ENV
+          echo "CMAKE_OSX_DEPLOYMENT_TARGET=15.0" >> $GITHUB_ENV
       - name: Install CUDA
         if: steps.run.outputs.should-run == 'true' && matrix.target == 'cuda' && matrix.cuda-version
         uses: ./.github/actions/setup-cuda

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -78,7 +78,7 @@ jobs:
             target: default
             package: node-whisper-darwin-x64
           # macOS arm64
-          - os: macos-15
+          - os: macos-26
             arch: arm64
             target: default
             package: node-whisper-darwin-arm64
@@ -147,6 +147,11 @@ jobs:
         if: steps.run.outputs.should-run == 'true'
         with:
           node-version: 20
+      - name: Select Xcode 26.2
+        if: steps.run.outputs.should-run == 'true' && matrix.os == 'macos-26'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.2'
       - name: Install CUDA
         if: steps.run.outputs.should-run == 'true' && matrix.target == 'cuda' && matrix.cuda-version
         uses: ./.github/actions/setup-cuda

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
       uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: '26.2'
+    - name: Set macOS deployment target
+      if: runner.os == 'macOS'
+      run: |
+        echo "MACOSX_DEPLOYMENT_TARGET=15.0" >> $GITHUB_ENV
+        echo "CMAKE_OSX_DEPLOYMENT_TARGET=15.0" >> $GITHUB_ENV
     - name: Install LLVM and Clang
       if: matrix.os == 'ubuntu-latest'
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,6 @@ jobs:
       uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: '26.2'
-    - name: Set macOS deployment target
-      if: runner.os == 'macOS'
-      run: |
-        echo "MACOSX_DEPLOYMENT_TARGET=15.0" >> $GITHUB_ENV
-        echo "CMAKE_OSX_DEPLOYMENT_TARGET=15.0" >> $GITHUB_ENV
     - name: Install LLVM and Clang
       if: matrix.os == 'ubuntu-latest'
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-26]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -15,6 +15,11 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: 20
+    - name: Select Xcode 26.2
+      if: runner.os == 'macOS'
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '26.2'
     - name: Install LLVM and Clang
       if: matrix.os == 'ubuntu-latest'
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,16 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT DEFINED GGML_OPENMP OR GGML_O
 endif()
 
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries")
+
+# Ensure ggml/Metal kernel compilation uses the same deployment target as the rest of the build.
+# whisper.cpp's ggml-metal backend supports -mmacosx-version-min via GGML_METAL_MACOSX_VERSION_MIN.
+if(APPLE AND NOT DEFINED GGML_METAL_MACOSX_VERSION_MIN)
+  if(DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
+    set(GGML_METAL_MACOSX_VERSION_MIN "${CMAKE_OSX_DEPLOYMENT_TARGET}")
+  elseif(DEFINED ENV{MACOSX_DEPLOYMENT_TARGET})
+    set(GGML_METAL_MACOSX_VERSION_MIN "$ENV{MACOSX_DEPLOYMENT_TARGET}")
+  endif()
+endif()
 add_subdirectory("whisper.cpp")
 
 if (NOT GGML_VULKAN AND NOT GGML_CUDA AND NOT GGML_METAL AND NOT GGML_CLBLAST)

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -2,6 +2,13 @@
 
 set -e
 
-# General
+# macOS deployment target
+#
+# Keep this out of GitHub Actions workflows so local builds and CI behave the same.
+# Default to 15.0 for Xcode 26+ compatibility, but allow callers to override.
+: "${MACOSX_DEPLOYMENT_TARGET:=15.0}"
+: "${CMAKE_OSX_DEPLOYMENT_TARGET:=${MACOSX_DEPLOYMENT_TARGET}}"
+export MACOSX_DEPLOYMENT_TARGET
+export CMAKE_OSX_DEPLOYMENT_TARGET
 
 npx cmake-js rebuild -C --CDTO_PACKAGE=ON

--- a/scripts/check.js
+++ b/scripts/check.js
@@ -2,19 +2,6 @@ const path = require('path');
 
 const validAccelerators = process.platform === 'darwin' ? [] : ['vulkan', 'cuda'];
 
-// macOS deployment target
-//
-// Keep this out of GitHub Actions workflows so local builds and CI behave the same.
-// Default to 15.0 for Xcode 26+ compatibility, but allow callers to override.
-if (process.platform === 'darwin') {
-  if (!process.env.MACOSX_DEPLOYMENT_TARGET) {
-    process.env.MACOSX_DEPLOYMENT_TARGET = '15.0'
-  }
-  if (!process.env.CMAKE_OSX_DEPLOYMENT_TARGET) {
-    process.env.CMAKE_OSX_DEPLOYMENT_TARGET = process.env.MACOSX_DEPLOYMENT_TARGET
-  }
-}
-
 const accelerator = process.env.npm_config_accelerator || '';
 
 if (process.env.npm_config_build_from_source) {

--- a/scripts/check.js
+++ b/scripts/check.js
@@ -2,6 +2,19 @@ const path = require('path');
 
 const validAccelerators = process.platform === 'darwin' ? [] : ['vulkan', 'cuda'];
 
+// macOS deployment target
+//
+// Keep this out of GitHub Actions workflows so local builds and CI behave the same.
+// Default to 15.0 for Xcode 26+ compatibility, but allow callers to override.
+if (process.platform === 'darwin') {
+  if (!process.env.MACOSX_DEPLOYMENT_TARGET) {
+    process.env.MACOSX_DEPLOYMENT_TARGET = '15.0'
+  }
+  if (!process.env.CMAKE_OSX_DEPLOYMENT_TARGET) {
+    process.env.CMAKE_OSX_DEPLOYMENT_TARGET = process.env.MACOSX_DEPLOYMENT_TARGET
+  }
+}
+
 const accelerator = process.env.npm_config_accelerator || '';
 
 if (process.env.npm_config_build_from_source) {


### PR DESCRIPTION
This updates GitHub Actions macOS jobs to explicitly use the macOS 26 runner image and pin Xcode 26.2 to ensure macOS 26.2 SDK/toolchain compatibility.

## Changes
- CI workflow: switch the macOS matrix entry from `macos-latest` to `macos-26` and add `maxim-lobanov/setup-xcode@v1` with `xcode-version: '26.2'`.
- Build release workflow: update the macOS arm64 build from `macos-15` to `macos-26` and pin Xcode 26.2 for that job.

## Why
- GitHub now provides macOS 26 runners (arm64 only):
  https://github.blog/changelog/2025-09-11-actions-macos-26-image-now-in-public-preview/
- The runner-images README for macos-26-arm64 lists Xcode 26.2 as installed and the default, and includes the macOS 26.2 SDK:
  https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md#xcode

## Notes
- macOS 26 runners are arm64-only; the existing Intel release build remains on `macos-15-intel`.
