### PR TITLE
feat: integrate parakeet model support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ if (WHISPER_NODE_WASM)
     "whisper.cpp/ggml/include"
   )
 
-  target_link_libraries(${WASM_TARGET} PRIVATE whisper)
+  target_link_libraries(${WASM_TARGET} PRIVATE whisper parakeet)
 
   set_target_properties(${WASM_TARGET} PROPERTIES
     OUTPUT_NAME ${WASM_OUTPUT_NAME}
@@ -253,6 +253,8 @@ file(
     "src/common.cpp"
     "src/WhisperContext.cpp"
     "src/WhisperContext.h"
+    "src/ParakeetContext.cpp"
+    "src/ParakeetContext.h"
 )
 list(APPEND SOURCE_FILES "whisper.cpp/examples/common-whisper.cpp")
 
@@ -274,7 +276,7 @@ endif()
 
 add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES} ${CMAKE_JS_SRC})
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
-target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB} whisper ggml ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB} whisper parakeet ggml ${CMAKE_THREAD_LIBS_INIT})
 
 add_custom_target(copy_assets ALL DEPENDS ${PROJECT_NAME})
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,41 @@ const result2 = await promise2
 await context.release()
 ```
 
+### NVIDIA Parakeet TDT
+
+`ParakeetContext` runs NVIDIA's Parakeet TDT 0.6B v3 model through the Parakeet API included in whisper.cpp. The v3 model supports English plus 24 other European languages.
+
+Download a GGUF model from [ggml-org/parakeet-GGUF](https://huggingface.co/ggml-org/parakeet-GGUF) before initializing the context:
+
+| Model | Approximate size |
+| --- | ---: |
+| `ggml-parakeet-tdt-0.6b-v3-q4_0.bin` | 356 MB |
+| `ggml-parakeet-tdt-0.6b-v3-q4_k.bin` | 416 MB |
+| `ggml-parakeet-tdt-0.6b-v3-q8_0.bin` | 669 MB |
+| `ggml-parakeet-tdt-0.6b-v3-f16.bin` | 1.26 GB |
+
+```js
+import { initParakeet } from '@fugood/whisper.node'
+
+const parakeetContext = await initParakeet({
+  filePath: 'path/to/ggml-parakeet-tdt-0.6b-v3-q4_0.bin',
+  useGpu: true,
+}, libVariant)
+
+// transcribeFile / transcribeData return { stop, promise } like WhisperContext
+const { stop, promise } = parakeetContext.transcribeFile('audio.wav', {
+  maxThreads: 4,
+})
+const { result, segments, isAborted } = await promise
+
+// Cancel an in-flight transcription when needed:
+// await stop()
+
+await parakeetContext.release()
+```
+
+`transcribeData()` accepts raw signed 16-bit PCM as ArrayBuffer; raw audio must be mono at 16 kHz. Whisper-specific options (language, prompt, callbacks) are not supported, use `maxThreads` and `audioCtx` instead.
+
 ### Voice Activity Detection (VAD)
 
 ```js
@@ -118,9 +153,9 @@ strings. The same helpers are available in Node.js and browser WASM builds.
 
 ### Browser WASM
 
-The browser package keeps the same promise-based `initWhisper` and
-`initWhisperVad` entry points. In browsers, `filePath` is treated as a URL and
-the model is fetched into the WASM filesystem.
+The browser package keeps the same promise-based `initWhisper`,
+`initWhisperVad`, and `initParakeet` entry points. In browsers, `filePath` is
+treated as a URL and the model is fetched into the WASM filesystem.
 
 ```js
 import { initWhisper, initWhisperVad } from '@fugood/whisper.node'

--- a/examples/parakeetTranscription.js
+++ b/examples/parakeetTranscription.js
@@ -1,0 +1,96 @@
+const fs = require('fs')
+const path = require('path')
+const { initParakeet } = require('../lib/index')
+
+// Configuration
+const MODEL_PATH = path.join(
+  __dirname,
+  '../whisper.cpp/models/ggml-parakeet-tdt-0.6b-v3-q4_0.bin',
+)
+const AUDIO_PATH = path.join(__dirname, '../whisper.cpp/samples/jfk.wav')
+
+/**
+ * Load WAV file and convert to ArrayBuffer (skipping WAV header)
+ */
+function loadWavFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Audio file not found: ${filePath}`)
+  }
+
+  const buffer = fs.readFileSync(filePath)
+
+  // WAV header is typically 44 bytes
+  const headerSize = 44
+  const audioData = buffer.slice(headerSize)
+
+  return audioData.buffer.slice(
+    audioData.byteOffset,
+    audioData.byteOffset + audioData.byteLength,
+  )
+}
+
+async function main() {
+  if (!fs.existsSync(MODEL_PATH)) {
+    console.error(`Model not found: ${MODEL_PATH}`)
+    console.error(
+      'Download it from https://huggingface.co/ggml-org/parakeet-GGUF ' +
+        'or run `node scripts/download-test-models.js`',
+    )
+    process.exit(1)
+  }
+
+  console.log('Loading parakeet model...')
+  console.log(`Model: ${MODEL_PATH}`)
+
+  // Initialize parakeet context
+  const context = await initParakeet({
+    filePath: MODEL_PATH,
+    useGpu: true, // Set to false if GPU is not available
+  })
+
+  console.log('Model loaded successfully!')
+  console.log()
+
+  // Load audio file
+  console.log(`Loading audio: ${AUDIO_PATH}`)
+  const audioBuffer = loadWavFile(AUDIO_PATH)
+  console.log(`Audio size: ${audioBuffer.byteLength} bytes`)
+  console.log()
+
+  console.log('Starting transcription...')
+  console.log()
+
+  const startTime = Date.now()
+
+  const { promise } = context.transcribeData(audioBuffer, {
+    maxThreads: 4,
+  })
+
+  const result = await promise
+
+  const elapsed = Date.now() - startTime
+
+  console.log('='.repeat(50))
+  console.log('Transcription complete!')
+  console.log('='.repeat(50))
+  console.log()
+  console.log('Full text:')
+  console.log(result.result)
+  console.log()
+  result.segments.forEach((segment) => {
+    const t0 = (segment.t0 / 1000).toFixed(2)
+    const t1 = (segment.t1 / 1000).toFixed(2)
+    console.log(`[${t0}s - ${t1}s] ${segment.text}`)
+  })
+  console.log()
+  console.log(`Time elapsed: ${elapsed}ms`)
+  console.log(`Segments: ${result.segments.length}`)
+  console.log(`Aborted: ${result.isAborted}`)
+
+  // Release context
+  await context.release()
+  console.log()
+  console.log('Context released.')
+}
+
+main().catch(console.error)

--- a/examples/wasm/index.html
+++ b/examples/wasm/index.html
@@ -99,6 +99,15 @@
       </label>
 
       <label>
+        Parakeet model URL (optional, skipped when empty)
+        <input
+          id="parakeet-model"
+          placeholder="https://huggingface.co/ggml-org/parakeet-GGUF/resolve/main/ggml-parakeet-tdt-0.6b-v3-q4_0.bin"
+          value=""
+        />
+      </label>
+
+      <label>
         Audio URL
         <input
           id="audio-url"
@@ -447,6 +456,7 @@
 
         const whisperModel = document.getElementById('whisper-model').value
         const vadModel = document.getElementById('vad-model').value
+        const parakeetModel = document.getElementById('parakeet-model').value.trim()
         const audioUrl = document.getElementById('audio-url').value
         const maxModelBytes = Number(document.getElementById('max-model-bytes').value)
         const cacheModel = document.getElementById('cache-model').checked
@@ -539,6 +549,38 @@
           )
           write('VAD result', segments)
           await timed('VAD release', () => vad.release())
+
+          if (parakeetModel) {
+            write('Loading parakeet model')
+            const parakeet = await timed(
+              'Parakeet model load',
+              () => WhisperNodeWasm.initParakeet({
+                filePath: toLocalUrl(parakeetModel),
+                maxModelBytes,
+                cacheModel,
+                useGpu,
+              }),
+              (context) => modelCacheDetails(context.getModelInfo()),
+            )
+            const parakeetInfo = parakeet.getModelInfo()
+            write('Parakeet model loaded', parakeetInfo)
+
+            write('Transcribing audio data with parakeet')
+            const parakeetResult = await timed(
+              'Parakeet transcribeData',
+              async () => {
+                const { promise } = parakeet.transcribeData(audioData, {
+                  maxThreads: effectiveMaxThreads,
+                })
+                return promise
+              },
+              (result) =>
+                `${result.segments.length} segments, ${effectiveMaxThreads} threads`,
+            )
+            write('Parakeet transcription result', parakeetResult)
+            await timed('Parakeet release', () => parakeet.release())
+          }
+
           appendTiming('Total', performance.now() - totalStartedAt)
         } catch (error) {
           write(error && error.stack ? error.stack : String(error))

--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -14,6 +14,13 @@ export interface NativeVadContextOptions {
   maxModelBytes?: number,
 }
 
+export interface NativeParakeetContextOptions {
+  filePath: string,
+  modelUrl?: string,
+  useGpu?: boolean,
+  maxModelBytes?: number,
+}
+
 export interface TranscribeOptions {
   language?: string
   translate?: boolean
@@ -46,6 +53,13 @@ export interface TranscribeNewSegmentsResult {
   totalNNew: number
   result: string
   segments: TranscribeResult['segments']
+}
+
+export interface ParakeetTranscribeOptions {
+  /** Number of threads to use during computation. */
+  maxThreads?: number
+  /** Override the model audio context size (0 uses the model default). */
+  audioCtx?: number
 }
 
 export interface TranscribeResult {
@@ -122,6 +136,39 @@ export interface WhisperContext {
   ): void
 }
 
+export interface ParakeetContext {
+  new (options: NativeParakeetContextOptions): ParakeetContext
+  transcribe(
+    filePath: string,
+    options?: ParakeetTranscribeOptions,
+  ): {
+    stop: () => Promise<void>
+    promise: Promise<TranscribeResult>
+  }
+  transcribeFile(
+    filePath: string,
+    options?: ParakeetTranscribeOptions,
+  ): {
+    stop: () => Promise<void>
+    promise: Promise<TranscribeResult>
+  }
+  transcribeData(
+    audioData: ArrayBuffer,
+    options?: ParakeetTranscribeOptions,
+  ): {
+    stop: () => Promise<void>
+    promise: Promise<TranscribeResult>
+  }
+  release(): Promise<void>
+  getModelInfo(): object
+
+  // static methods
+  toggleNativeLog(
+    enable: boolean,
+    callback?: (level: string, text: string) => void,
+  ): void
+}
+
 export interface WhisperVadContext {
   new (options: NativeVadContextOptions): WhisperVadContext
   detectSpeech(filePath: string, options?: VadOptions): Promise<VadSegment[]>
@@ -143,6 +190,7 @@ export interface WhisperVadContext {
 export interface Module {
   WhisperContext: WhisperContext
   WhisperVadContext: WhisperVadContext
+  ParakeetContext: ParakeetContext
 }
 
 export type LibVariant = 'default' | 'vulkan' | 'cuda'

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,9 +2,12 @@ import { loadModule } from './binding';
 import type {
   WhisperContext,
   WhisperVadContext,
+  ParakeetContext,
   NativeContextOptions,
   NativeVadContextOptions,
+  NativeParakeetContextOptions,
   TranscribeOptions,
+  ParakeetTranscribeOptions,
   TranscribeResult,
   TranscribeNewSegmentsResult,
   VadOptions,
@@ -18,9 +21,12 @@ import type {
 export type {
   WhisperContext,
   WhisperVadContext,
+  ParakeetContext,
   NativeContextOptions,
   NativeVadContextOptions,
+  NativeParakeetContextOptions,
   TranscribeOptions,
+  ParakeetTranscribeOptions,
   TranscribeResult,
   TranscribeNewSegmentsResult,
   VadOptions,
@@ -81,9 +87,12 @@ const refreshNativeLogSetup = () => {
     if (logEnabled) {
       moduleCache.WhisperContext.toggleNativeLog(logEnabled, logCallback)
       moduleCache.WhisperVadContext.toggleNativeLog(logEnabled, logCallback)
+      // Older prebuilt packages may not export ParakeetContext
+      moduleCache.ParakeetContext?.toggleNativeLog(logEnabled, logCallback)
     } else {
       moduleCache.WhisperContext.toggleNativeLog(false)
       moduleCache.WhisperVadContext.toggleNativeLog(false)
+      moduleCache.ParakeetContext?.toggleNativeLog(false)
     }
   }
 }
@@ -153,12 +162,34 @@ export const initWhisperVad = async (
     | Promise<WhisperVadContext>);
 };
 
+/**
+ * Create a new ParakeetContext for transcription with NVIDIA Parakeet models
+ * @param options - Configuration options for the parakeet model
+ * @param variant - Optional backend variant to use
+ * @returns Promise that resolves to a ParakeetContext instance
+ */
+export const initParakeet = async (
+  options: NativeParakeetContextOptions,
+  variant?: LibVariant
+): Promise<ParakeetContext> => {
+  const module = await loadWhisperModule(variant);
+  if (!module.ParakeetContext) {
+    throw new Error(
+      'ParakeetContext is not available in the loaded whisper.node binary, please update the platform package',
+    );
+  }
+  return await (new module.ParakeetContext(options) as
+    | ParakeetContext
+    | Promise<ParakeetContext>);
+};
+
 export const isNativeLogEnabled = () => logEnabled
 
 // Default export
 export default {
   initWhisper,
   initWhisperVad,
+  initParakeet,
   loadWhisperModule,
   toggleNativeLog,
   addNativeLogListener,

--- a/lib/node-whisper-wasm.d.ts
+++ b/lib/node-whisper-wasm.d.ts
@@ -11,6 +11,7 @@ declare module '@fugood/node-whisper-wasm' {
   export function isNativeLogEnabled(): boolean
   export const WhisperContext: Module['WhisperContext']
   export const WhisperVadContext: Module['WhisperVadContext']
+  export const ParakeetContext: Module['ParakeetContext']
   const module: Module & {
     default?: Module
     toggleNativeLog: typeof toggleNativeLog

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
   "homepage": "https://github.com/whisper-node/whisper.node#readme",
   "jest": {
     "testEnvironment": "node",
+    "maxWorkers": 1,
     "moduleFileExtensions": [
       "ts",
       "tsx",

--- a/packages/node-whisper-wasm/README.md
+++ b/packages/node-whisper-wasm/README.md
@@ -4,9 +4,10 @@ Browser WASM implementation package for `@fugood/whisper.node`. Application
 code should import `@fugood/whisper.node`; this package is pulled in by the main
 package for browser builds.
 
-The package exposes the same high-level context API as the native packages, but
-model and audio file paths are fetched as URLs and copied into the Emscripten
-filesystem before inference.
+The package exposes the same high-level context API as the native packages
+(`initWhisper`, `initWhisperVad`, and `initParakeet`), but model and audio file
+paths are fetched as URLs and copied into the Emscripten filesystem before
+inference.
 
 ```js
 import { initWhisper } from '@fugood/whisper.node'

--- a/packages/node-whisper-wasm/index.d.ts
+++ b/packages/node-whisper-wasm/index.d.ts
@@ -22,6 +22,17 @@ export interface NativeVadContextOptions {
   worker?: boolean
 }
 
+export interface NativeParakeetContextOptions {
+  filePath: string
+  modelUrl?: string
+  useGpu?: boolean
+  maxModelBytes?: number
+  cacheModel?: boolean
+  modelCacheName?: string
+  modelCacheKey?: string
+  worker?: boolean
+}
+
 export interface TranscribeOptions {
   language?: string
   translate?: boolean
@@ -59,6 +70,13 @@ export interface TranscribeResult {
     t1: number
   }>
   isAborted: boolean
+}
+
+export interface ParakeetTranscribeOptions {
+  /** Number of threads to use during computation. */
+  maxThreads?: number
+  /** Override the model audio context size (0 uses the model default). */
+  audioCtx?: number
 }
 
 export interface VadOptions {
@@ -111,6 +129,32 @@ export interface WhisperContext {
   getModelInfo(): object
 }
 
+export interface ParakeetContext {
+  transcribe(
+    filePath: string,
+    options?: ParakeetTranscribeOptions,
+  ): {
+    stop: () => Promise<void>
+    promise: Promise<TranscribeResult>
+  }
+  transcribeFile(
+    filePath: string,
+    options?: ParakeetTranscribeOptions,
+  ): {
+    stop: () => Promise<void>
+    promise: Promise<TranscribeResult>
+  }
+  transcribeData(
+    audioData: ArrayBuffer | ArrayBufferView | Float32Array,
+    options?: ParakeetTranscribeOptions,
+  ): {
+    stop: () => Promise<void>
+    promise: Promise<TranscribeResult>
+  }
+  release(): Promise<void>
+  getModelInfo(): object
+}
+
 export interface WhisperVadContext {
   detectSpeech(filePath: string, options?: VadOptions): Promise<VadSegment[]>
   detectSpeechFile(filePath: string, options?: VadOptions): Promise<VadSegment[]>
@@ -132,6 +176,13 @@ export interface Module {
   }
   WhisperVadContext: {
     new (options: NativeVadContextOptions): Promise<WhisperVadContext>
+    toggleNativeLog(
+      enable: boolean,
+      callback?: (level: string, text: string) => void,
+    ): void | Promise<void>
+  }
+  ParakeetContext: {
+    new (options: NativeParakeetContextOptions): Promise<ParakeetContext>
     toggleNativeLog(
       enable: boolean,
       callback?: (level: string, text: string) => void,
@@ -161,6 +212,7 @@ export interface WasmRuntimeOptions {
 
 export declare const WhisperContext: Module['WhisperContext']
 export declare const WhisperVadContext: Module['WhisperVadContext']
+export declare const ParakeetContext: Module['ParakeetContext']
 export declare const DEFAULT_WASM_MODEL_SIZE_LIMIT_BYTES: number
 export declare const MAX_WASM_THREADS: number
 export declare const WASM_CONFIG_PATHS: {
@@ -182,6 +234,9 @@ export declare function initWhisper(
 export declare function initWhisperVad(
   options: NativeVadContextOptions,
 ): Promise<WhisperVadContext>
+export declare function initParakeet(
+  options: NativeParakeetContextOptions,
+): Promise<ParakeetContext>
 export declare function toggleNativeLog(
   enable: boolean,
   callback?: (level: string, text: string) => void,
@@ -194,11 +249,13 @@ export declare function isNativeLogEnabled(): boolean
 declare const _default: {
   WhisperContext: typeof WhisperContext
   WhisperVadContext: typeof WhisperVadContext
+  ParakeetContext: typeof ParakeetContext
   configureWasm: typeof configureWasm
   loadWasmModule: typeof loadWasmModule
   loadWhisperModule: typeof loadWhisperModule
   initWhisper: typeof initWhisper
   initWhisperVad: typeof initWhisperVad
+  initParakeet: typeof initParakeet
   toggleNativeLog: typeof toggleNativeLog
   addNativeLogListener: typeof addNativeLogListener
   isNativeLogEnabled: typeof isNativeLogEnabled

--- a/packages/node-whisper-wasm/index.js
+++ b/packages/node-whisper-wasm/index.js
@@ -1340,6 +1340,244 @@ const createWhisperNodeApi = function (root) {
       return Promise.resolve()
     }
 
+    function ParakeetContext(options) {
+      if (shouldUseWorker(options || {})) {
+        return createWorkerParakeetContext(options || {})
+      }
+      return createParakeetContext(options)
+    }
+
+    ParakeetContext.toggleNativeLog = toggleNativeLog
+    ParakeetContext.loadModelInfo = function (path) {
+      return {
+        path: path,
+        type: 'parakeet',
+      }
+    }
+
+    async function createWorkerParakeetContext(options) {
+      var proxy = await getWorkerProxy()
+      if (!proxy) {
+        return createParakeetContext(options)
+      }
+
+      var created = await proxy.request('initParakeet', [options || {}])
+      created.meta.worker = true
+      return new WorkerParakeetContextInstance(proxy, created.id, created.meta)
+    }
+
+    function WorkerParakeetContextInstance(proxy, id, meta) {
+      this._proxy = proxy
+      this._id = id
+      this._meta = meta
+      this._released = false
+    }
+
+    WorkerParakeetContextInstance.prototype._assertValid = function () {
+      if (this._released) {
+        throw new Error('Invalid parakeet context')
+      }
+    }
+
+    WorkerParakeetContextInstance.prototype.getModelInfo = function () {
+      return this._meta
+    }
+
+    WorkerParakeetContextInstance.prototype._transcribeWorker = function (
+      method,
+      args,
+      transfer,
+    ) {
+      this._assertValid()
+
+      var cancelled = false
+      var operation = this._proxy.requestOperation(method, args, transfer, {})
+      var proxy = this._proxy
+
+      return {
+        _requestId: operation.id,
+        stop: function () {
+          cancelled = true
+          proxy.cancel(operation.id)
+          return Promise.resolve()
+        },
+        promise: operation.promise.then(function (result) {
+          if (cancelled) {
+            result.isAborted = true
+          }
+          return result
+        }),
+      }
+    }
+
+    WorkerParakeetContextInstance.prototype.transcribeData = function (
+      audioData,
+      options,
+    ) {
+      var audio = copyFloat32Audio(audioData)
+      return this._transcribeWorker(
+        'parakeetTranscribeData',
+        [this._id, audio, normalizeThreadOptions(options)],
+        [audio.buffer],
+      )
+    }
+
+    WorkerParakeetContextInstance.prototype.transcribeFile = function (
+      filePath,
+      options,
+    ) {
+      return this._transcribeWorker(
+        'parakeetTranscribeFile',
+        [this._id, filePath, normalizeThreadOptions(options)],
+        [],
+      )
+    }
+
+    WorkerParakeetContextInstance.prototype.transcribe =
+      WorkerParakeetContextInstance.prototype.transcribeFile
+
+    WorkerParakeetContextInstance.prototype.release = async function () {
+      if (!this._released) {
+        await this._proxy.request('releaseParakeet', [this._id])
+        this._released = true
+      }
+    }
+
+    async function createParakeetContext(options) {
+      options = options || {}
+      var modelSource = options.filePath || options.modelUrl
+      var runtime = await loadRuntime()
+      if (typeof runtime.__wasm_init_parakeet !== 'function') {
+        throw new Error(
+          'ParakeetContext is not available in this @fugood/node-whisper-wasm build, please update the package',
+        )
+      }
+      var useGpu = resolveWhisperGpu(runtime, options.useGpu === true)
+
+      var model = await ensureModel(runtime, modelSource, 'parakeet', options)
+      var init
+      try {
+        init = unwrapWasmResult(
+          await runtime.__wasm_init_parakeet(model.virtualPath, useGpu),
+        )
+      } catch (error) {
+        if (!useGpu) {
+          throw error
+        }
+        warnWebGpuCpuFallback(error)
+        useGpu = false
+        init = unwrapWasmResult(
+          await runtime.__wasm_init_parakeet(model.virtualPath, false),
+        )
+      }
+
+      return new ParakeetContextInstance(runtime, init.id, {
+        filePath: modelSource,
+        wasmFilePath: model.virtualPath,
+        useGpu: useGpu,
+        bytes: model.bytes,
+        cacheHit: model.cacheHit,
+        cacheStored: model.cacheStored,
+        cacheName: model.cacheName,
+        cacheKey: model.cacheKey,
+        wasm: true,
+      })
+    }
+
+    function ParakeetContextInstance(runtime, id, meta) {
+      this._runtime = runtime
+      this._id = id
+      this._meta = meta
+      this._released = false
+    }
+
+    ParakeetContextInstance.prototype._assertValid = function () {
+      if (this._released) {
+        throw new Error('Invalid parakeet context')
+      }
+    }
+
+    ParakeetContextInstance.prototype.getModelInfo = function () {
+      return this._meta
+    }
+
+    ParakeetContextInstance.prototype._transcribeFloat32 = function (
+      audio,
+      options,
+      isCancelled,
+    ) {
+      this._assertValid()
+
+      if (isCancelled && isCancelled()) {
+        return Promise.resolve(abortedResult())
+      }
+
+      var runtime = this._runtime
+      var id = this._id
+      return defer(async function () {
+        if (isCancelled && isCancelled()) {
+          return abortedResult()
+        }
+
+        var result = unwrapWasmResult(
+          await runtime.__wasm_transcribe_parakeet(
+            id,
+            audio,
+            normalizeThreadOptions(options, runtime),
+          ),
+        )
+        if (isCancelled && isCancelled()) {
+          result.isAborted = true
+        }
+        return result
+      })
+    }
+
+    ParakeetContextInstance.prototype.transcribeData = function (audioData, options) {
+      var cancelled = false
+      var audio = toFloat32Audio(audioData)
+      return {
+        stop: function () {
+          cancelled = true
+          return Promise.resolve()
+        },
+        promise: this._transcribeFloat32(audio, options, function () {
+          return cancelled
+        }),
+      }
+    }
+
+    ParakeetContextInstance.prototype.transcribeFile = function (filePath, options) {
+      var cancelled = false
+      var self = this
+      return {
+        stop: function () {
+          cancelled = true
+          return Promise.resolve()
+        },
+        promise: (async function () {
+          if (cancelled) {
+            return abortedResult()
+          }
+          var audio = await loadAudioUrl(filePath)
+          return self._transcribeFloat32(audio, options, function () {
+            return cancelled
+          })
+        })(),
+      }
+    }
+
+    ParakeetContextInstance.prototype.transcribe =
+      ParakeetContextInstance.prototype.transcribeFile
+
+    ParakeetContextInstance.prototype.release = function () {
+      if (!this._released) {
+        this._runtime.__wasm_free_parakeet(this._id)
+        this._released = true
+      }
+      return Promise.resolve()
+    }
+
     function WhisperVadContext(options) {
       if (shouldUseWorker(options || {})) {
         return createWorkerWhisperVadContext(options || {})
@@ -1509,14 +1747,20 @@ const createWhisperNodeApi = function (root) {
       return Promise.resolve(new WhisperVadContext(options))
     }
 
+    function initParakeet(options) {
+      return Promise.resolve(new ParakeetContext(options))
+    }
+
     var api = {
       WhisperContext: WhisperContext,
       WhisperVadContext: WhisperVadContext,
+      ParakeetContext: ParakeetContext,
       configureWasm: configureWasm,
       loadWasmModule: loadRuntime,
       loadWhisperModule: loadWhisperModule,
       initWhisper: initWhisper,
       initWhisperVad: initWhisperVad,
+      initParakeet: initParakeet,
       toggleNativeLog: toggleNativeLog,
       addNativeLogListener: addNativeLogListener,
       isNativeLogEnabled: function () {
@@ -1537,6 +1781,7 @@ const api = createWhisperNodeApi(root)
 
 export const WhisperContext = api.WhisperContext
 export const WhisperVadContext = api.WhisperVadContext
+export const ParakeetContext = api.ParakeetContext
 export const DEFAULT_WASM_MODEL_SIZE_LIMIT_BYTES =
   api.DEFAULT_WASM_MODEL_SIZE_LIMIT_BYTES
 export const MAX_WASM_THREADS = api.MAX_WASM_THREADS
@@ -1545,6 +1790,7 @@ export const loadWasmModule = api.loadWasmModule
 export const loadWhisperModule = api.loadWhisperModule
 export const initWhisper = api.initWhisper
 export const initWhisperVad = api.initWhisperVad
+export const initParakeet = api.initParakeet
 export const toggleNativeLog = api.toggleNativeLog
 export const addNativeLogListener = api.addNativeLogListener
 export const isNativeLogEnabled = api.isNativeLogEnabled

--- a/packages/node-whisper-wasm/worker.js
+++ b/packages/node-whisper-wasm/worker.js
@@ -190,6 +190,46 @@ import WhisperNodeWasm from './index.js'
         delete contexts[args[0]]
         return { ok: true }
 
+      case 'initParakeet': {
+        var parakeet = await api.initParakeet(args[0] || {})
+        var parakeetId = nextContextId++
+        contexts[parakeetId] = {
+          type: 'parakeet',
+          context: parakeet,
+        }
+        return {
+          id: parakeetId,
+          meta: parakeet.getModelInfo(),
+        }
+      }
+
+      case 'parakeetTranscribeData': {
+        if (cancelledRequests[message.id]) {
+          return abortedResult()
+        }
+        var parakeetDataContext = getContext(args[0], 'parakeet')
+        return runTranscribeOperation(
+          message.id,
+          parakeetDataContext.transcribeData(args[1], args[2] || {}),
+        )
+      }
+
+      case 'parakeetTranscribeFile': {
+        if (cancelledRequests[message.id]) {
+          return abortedResult()
+        }
+        var parakeetFileContext = getContext(args[0], 'parakeet')
+        return runTranscribeOperation(
+          message.id,
+          parakeetFileContext.transcribeFile(args[1], args[2] || {}),
+        )
+      }
+
+      case 'releaseParakeet':
+        await getContext(args[0], 'parakeet').release()
+        delete contexts[args[0]]
+        return { ok: true }
+
       case 'initWhisperVad': {
         var vad = await api.initWhisperVad(args[0] || {})
         var vadId = nextContextId++

--- a/scripts/download-test-models.js
+++ b/scripts/download-test-models.js
@@ -30,6 +30,11 @@ const requiredModels = [
     fileName: 'ggml-silero-v6.2.0.bin',
     url: 'https://huggingface.co/ggml-org/whisper-vad/resolve/main/ggml-silero-v6.2.0.bin',
   },
+  {
+    name: 'parakeet-tdt-0.6b-v3-q4_0',
+    fileName: 'ggml-parakeet-tdt-0.6b-v3-q4_0.bin',
+    url: 'https://huggingface.co/ggml-org/parakeet-GGUF/resolve/main/ggml-parakeet-tdt-0.6b-v3-q4_0.bin',
+  },
 ]
 
 function formatBytes(bytes) {

--- a/src/ParakeetContext.cpp
+++ b/src/ParakeetContext.cpp
@@ -1,0 +1,391 @@
+#include "ParakeetContext.h"
+#include "common.hpp"
+#include "parakeet.h"
+#include <thread>
+
+// Helper class for async Parakeet transcription
+class ParakeetTranscribeWorker : public Napi::AsyncWorker {
+public:
+    ParakeetTranscribeWorker(
+        const Napi::Function& callback,
+        ParakeetSessionPtr session,
+        const std::vector<float>& audioData,
+        const parakeet_full_params& params,
+        std::shared_ptr<std::atomic<bool>> cancelFlag
+    ) : AsyncWorker(callback), session_(session), audioData_(audioData), params_(params),
+        cancelFlag_(cancelFlag) {}
+
+protected:
+    void Execute() override {
+        if (!session_ || !session_->isValid()) {
+            SetError("Invalid parakeet context");
+            return;
+        }
+
+        // Handle empty audio data gracefully
+        if (audioData_.empty()) {
+            return;
+        }
+
+        // Lock the session to ensure thread safety
+        std::lock_guard<std::mutex> lock(session_->mtx);
+
+        if (!session_->ctx) {
+            SetError("Parakeet context was destroyed");
+            return;
+        }
+
+        if (cancelFlag_ && cancelFlag_->load()) {
+            aborted_ = true;
+            return;
+        }
+
+        // Wire the cancellation flag into the ggml abort callback so stop()
+        // interrupts the computation instead of waiting for completion
+        parakeet_full_params params_copy = params_;
+        params_copy.abort_callback = [](void* user_data) -> bool {
+            auto* flag = static_cast<std::atomic<bool>*>(user_data);
+            return flag && flag->load();
+        };
+        params_copy.abort_callback_user_data = cancelFlag_.get();
+
+        int result = parakeet_full(session_->ctx, params_copy, audioData_.data(), audioData_.size());
+
+        aborted_ = cancelFlag_ && cancelFlag_->load();
+
+        if (result != 0 && !aborted_) {
+            SetError("Parakeet transcription failed");
+            return;
+        }
+    }
+
+    void OnOK() override {
+        if (!session_ || !session_->isValid()) {
+            Callback().Call({Napi::Error::New(Env(), "Context was destroyed").Value(), Env().Null()});
+            return;
+        }
+
+        // Handle empty audio data case
+        if (audioData_.empty()) {
+            auto result = whisper_utils::createParakeetTranscribeResult(Env(), nullptr, aborted_);
+            Callback().Call({Env().Null(), result});
+            return;
+        }
+
+        std::lock_guard<std::mutex> lock(session_->mtx);
+        auto result = whisper_utils::createParakeetTranscribeResult(Env(), session_->ctx, aborted_);
+
+        Callback().Call({Env().Null(), result});
+    }
+
+    void OnError(const Napi::Error& error) override {
+        AsyncWorker::OnError(error);
+    }
+
+private:
+    ParakeetSessionPtr session_;  // Hold shared pointer instead of raw pointer
+    std::vector<float> audioData_;
+    parakeet_full_params params_;
+    std::shared_ptr<std::atomic<bool>> cancelFlag_;
+    bool aborted_ = false;
+};
+
+// ParakeetContext implementation
+ParakeetContext::ParakeetContext(const Napi::CallbackInfo& info) : Napi::ObjectWrap<ParakeetContext>(info) {
+    Napi::Env env = info.Env();
+
+    if (info.Length() < 1 || !info[0].IsObject()) {
+        Napi::TypeError::New(env, "Expected options object").ThrowAsJavaScriptException();
+        return;
+    }
+
+    auto options = info[0].As<Napi::Object>();
+    std::string modelPath = whisper_utils::getString(options.Get("filePath"));
+    bool useGpu = whisper_utils::getBool(options.Get("useGpu"), USE_GPU);
+
+    if (modelPath.empty()) {
+        Napi::TypeError::New(env, "Model path is required").ThrowAsJavaScriptException();
+        return;
+    }
+
+    // Initialize parakeet context
+    parakeet_context_params cparams = parakeet_context_default_params();
+    cparams.use_gpu = useGpu;
+    cparams.gpu_device = 0;
+
+    parakeet_context* ctx = parakeet_init_from_file_with_params(modelPath.c_str(), cparams);
+    if (!ctx) {
+        Napi::Error::New(env, "Failed to initialize parakeet context").ThrowAsJavaScriptException();
+        return;
+    }
+
+    _sess = std::make_shared<ParakeetSession>(modelPath, ctx);
+
+    // Build metadata (persistent reference so it outlives the constructor scope)
+    auto meta = Napi::Object::New(env);
+    meta.Set("filePath", modelPath);
+    meta.Set("useGpu", useGpu);
+    _meta = Napi::Persistent(meta);
+}
+
+ParakeetContext::~ParakeetContext() {
+    // Note: The worker holds a shared pointer to the session, so it stays
+    // alive until any running transcription finishes
+}
+
+// Job tracking methods
+int ParakeetContext::registerJob(std::shared_ptr<std::atomic<bool>> cancelFlag) {
+    std::lock_guard<std::mutex> lock(_cancelMutex);
+    int jobId = _nextJobId++;
+    _cancelFlags[jobId] = cancelFlag;
+    return jobId;
+}
+
+void ParakeetContext::unregisterJob(int jobId) {
+    std::lock_guard<std::mutex> lock(_cancelMutex);
+    _cancelFlags.erase(jobId);
+}
+
+void ParakeetContext::ToggleNativeLog(const Napi::CallbackInfo& info) {
+    toggle_native_log(info);
+}
+
+Napi::Value ParakeetContext::ModelInfo(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+
+    if (info.Length() < 1) {
+        Napi::TypeError::New(env, "Expected model path").ThrowAsJavaScriptException();
+        return env.Null();
+    }
+
+    std::string path = whisper_utils::getString(info[0]);
+
+    auto modelInfo = Napi::Object::New(env);
+    modelInfo.Set("path", path);
+    modelInfo.Set("type", "parakeet");
+
+    return modelInfo;
+}
+
+void ParakeetContext::Init(Napi::Env env, Napi::Object& exports) {
+    Napi::Function func = DefineClass(env, "ParakeetContext", {
+        StaticMethod("toggleNativeLog", &ParakeetContext::ToggleNativeLog),
+        StaticMethod("loadModelInfo", &ParakeetContext::ModelInfo),
+        InstanceMethod("getModelInfo", &ParakeetContext::GetModelInfo),
+        InstanceMethod("transcribeFile", &ParakeetContext::TranscribeFile),
+        InstanceMethod("transcribe", &ParakeetContext::TranscribeFile),
+        InstanceMethod("transcribeData", &ParakeetContext::TranscribeData),
+        InstanceMethod("abortTranscribe", &ParakeetContext::AbortTranscribe),
+        InstanceMethod("release", &ParakeetContext::Release),
+    });
+
+    exports.Set("ParakeetContext", func);
+}
+
+Napi::Value ParakeetContext::GetModelInfo(const Napi::CallbackInfo& info) {
+    if (_meta.IsEmpty()) {
+        return info.Env().Null();
+    }
+    return _meta.Value();
+}
+
+Napi::Value ParakeetContext::TranscribeFile(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+
+    if (info.Length() < 1) {
+        Napi::TypeError::New(env, "Expected file path").ThrowAsJavaScriptException();
+        return env.Null();
+    }
+
+    std::string filePath = whisper_utils::getString(info[0]);
+    auto options = info.Length() >= 2 && info[1].IsObject() ?
+        info[1].As<Napi::Object>() : Napi::Object::New(env);
+
+    if (!_sess || !_sess->isValid()) {
+        Napi::Error::New(env, "Invalid parakeet context").ThrowAsJavaScriptException();
+        return env.Null();
+    }
+
+    // Create cancellation flag
+    auto cancelFlag = std::make_shared<std::atomic<bool>>(false);
+    int jobId = registerJob(cancelFlag);
+
+    auto deferred = Napi::Promise::Deferred::New(env);
+
+    try {
+        // Load audio file
+        std::vector<float> audioData = whisper_utils::loadAudioFile(filePath);
+
+        // Create parameters
+        parakeet_full_params params = whisper_utils::createParakeetParamsFromOptions(options);
+
+        // Create async worker with cancellation support
+        auto callback = Napi::Function::New(env, [deferred, this, jobId](const Napi::CallbackInfo& cbInfo) {
+            // Clean up job tracking
+            this->unregisterJob(jobId);
+
+            if (cbInfo.Length() >= 2) {
+                if (!cbInfo[0].IsNull()) {
+                    deferred.Reject(cbInfo[0]);
+                } else {
+                    deferred.Resolve(cbInfo[1]);
+                }
+            }
+        });
+
+        auto worker = new ParakeetTranscribeWorker(callback, _sess, audioData, params, cancelFlag);
+        worker->Queue();
+
+    } catch (const std::exception& e) {
+        unregisterJob(jobId);
+        deferred.Reject(Napi::Error::New(env, e.what()).Value());
+    }
+
+    // Create the return object with stop and promise
+    auto result = Napi::Object::New(env);
+
+    // Create stop function
+    auto stopFunction = Napi::Function::New(env, [this, jobId](const Napi::CallbackInfo& stopInfo) {
+        Napi::Env env = stopInfo.Env();
+
+        // Cancel the job directly
+        {
+            std::lock_guard<std::mutex> lock(this->_cancelMutex);
+            auto it = this->_cancelFlags.find(jobId);
+            if (it != this->_cancelFlags.end()) {
+                it->second->store(true);
+            }
+        }
+
+        auto deferred = Napi::Promise::Deferred::New(env);
+        deferred.Resolve(env.Undefined());
+        return deferred.Promise();
+    });
+
+    result.Set("stop", stopFunction);
+    result.Set("promise", deferred.Promise());
+
+    return result;
+}
+
+Napi::Value ParakeetContext::TranscribeData(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+
+    if (info.Length() < 1 || !info[0].IsArrayBuffer()) {
+        Napi::TypeError::New(env, "Expected ArrayBuffer").ThrowAsJavaScriptException();
+        return env.Null();
+    }
+
+    auto audioBuffer = info[0].As<Napi::ArrayBuffer>();
+    auto options = info.Length() >= 2 && info[1].IsObject() ?
+        info[1].As<Napi::Object>() : Napi::Object::New(env);
+
+    if (!_sess || !_sess->isValid()) {
+        Napi::Error::New(env, "Invalid parakeet context").ThrowAsJavaScriptException();
+        return env.Null();
+    }
+
+    // Create cancellation flag
+    auto cancelFlag = std::make_shared<std::atomic<bool>>(false);
+    int jobId = registerJob(cancelFlag);
+
+    auto deferred = Napi::Promise::Deferred::New(env);
+
+    try {
+        // Convert ArrayBuffer to float array
+        std::vector<float> audioData = whisper_utils::convertAudioBufferToFloat(audioBuffer);
+
+        // Create parameters
+        parakeet_full_params params = whisper_utils::createParakeetParamsFromOptions(options);
+
+        // Create async worker with cancellation support
+        auto callback = Napi::Function::New(env, [deferred, this, jobId](const Napi::CallbackInfo& cbInfo) {
+            // Clean up job tracking
+            this->unregisterJob(jobId);
+
+            if (cbInfo.Length() >= 2) {
+                if (!cbInfo[0].IsNull()) {
+                    deferred.Reject(cbInfo[0]);
+                } else {
+                    deferred.Resolve(cbInfo[1]);
+                }
+            }
+        });
+
+        auto worker = new ParakeetTranscribeWorker(callback, _sess, audioData, params, cancelFlag);
+        worker->Queue();
+
+    } catch (const std::exception& e) {
+        unregisterJob(jobId);
+        deferred.Reject(Napi::Error::New(env, e.what()).Value());
+    }
+
+    // Create the return object with stop and promise
+    auto result = Napi::Object::New(env);
+
+    // Create stop function
+    auto stopFunction = Napi::Function::New(env, [this, jobId](const Napi::CallbackInfo& stopInfo) {
+        Napi::Env env = stopInfo.Env();
+
+        // Cancel the job directly
+        {
+            std::lock_guard<std::mutex> lock(this->_cancelMutex);
+            auto it = this->_cancelFlags.find(jobId);
+            if (it != this->_cancelFlags.end()) {
+                it->second->store(true);
+            }
+        }
+
+        auto deferred = Napi::Promise::Deferred::New(env);
+        deferred.Resolve(env.Undefined());
+        return deferred.Promise();
+    });
+
+    result.Set("stop", stopFunction);
+    result.Set("promise", deferred.Promise());
+
+    return result;
+}
+
+Napi::Value ParakeetContext::AbortTranscribe(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+
+    if (info.Length() < 1 || !info[0].IsNumber()) {
+        Napi::TypeError::New(env, "Expected job ID").ThrowAsJavaScriptException();
+        return env.Null();
+    }
+
+    int jobId = info[0].As<Napi::Number>().Int32Value();
+
+    {
+        std::lock_guard<std::mutex> lock(_cancelMutex);
+        auto it = _cancelFlags.find(jobId);
+        if (it != _cancelFlags.end()) {
+            it->second->store(true);
+        }
+    }
+
+    auto deferred = Napi::Promise::Deferred::New(env);
+    deferred.Resolve(env.Undefined());
+    return deferred.Promise();
+}
+
+Napi::Value ParakeetContext::Release(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    auto deferred = Napi::Promise::Deferred::New(env);
+
+    // Cancel all running jobs
+    {
+        std::lock_guard<std::mutex> lock(_cancelMutex);
+        for (auto& [jobId, cancelFlag] : _cancelFlags) {
+            cancelFlag->store(true);
+        }
+        _cancelFlags.clear();
+    }
+
+    // The shared_ptr will ensure the context stays alive until any running worker finishes
+    _sess.reset();
+    deferred.Resolve(env.Undefined());
+
+    return deferred.Promise();
+}

--- a/src/ParakeetContext.h
+++ b/src/ParakeetContext.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "common.hpp"
+#include <atomic>
+#include <unordered_map>
+
+#ifndef USE_GPU
+#ifdef NO_GPU_SUPPORT
+#define USE_GPU false
+#else
+#define USE_GPU true
+#endif
+#endif
+
+class ParakeetContext : public Napi::ObjectWrap<ParakeetContext> {
+public:
+    ParakeetContext(const Napi::CallbackInfo& info);
+    ~ParakeetContext();
+
+    // Static methods
+    static void ToggleNativeLog(const Napi::CallbackInfo& info);
+    static Napi::Value ModelInfo(const Napi::CallbackInfo& info);
+    static void Init(Napi::Env env, Napi::Object& exports);
+
+private:
+    // Instance methods
+    Napi::Value GetModelInfo(const Napi::CallbackInfo& info);
+    Napi::Value TranscribeFile(const Napi::CallbackInfo& info);
+    Napi::Value TranscribeData(const Napi::CallbackInfo& info);
+    Napi::Value AbortTranscribe(const Napi::CallbackInfo& info);
+    Napi::Value Release(const Napi::CallbackInfo& info);
+
+    // Internal data
+    Napi::ObjectReference _meta;
+    ParakeetSessionPtr _sess = nullptr;
+
+    // Job tracking for cancellation
+    std::atomic<int> _nextJobId{1};
+    std::unordered_map<int, std::shared_ptr<std::atomic<bool>>> _cancelFlags;
+    std::mutex _cancelMutex;
+
+public:
+    // Public method to register a job for cancellation
+    int registerJob(std::shared_ptr<std::atomic<bool>> cancelFlag);
+    void unregisterJob(int jobId);
+};

--- a/src/WhisperContext.cpp
+++ b/src/WhisperContext.cpp
@@ -389,11 +389,12 @@ WhisperContext::WhisperContext(const Napi::CallbackInfo& info) : Napi::ObjectWra
 
     _sess = std::make_shared<WhisperSession>(modelPath, ctx);
 
-    // Build metadata
-    _meta = Napi::Object::New(env);
-    _meta.Set("filePath", modelPath);
-    _meta.Set("useGpu", useGpu);
-    _meta.Set("useFlashAttn", useFlashAttn);
+    // Build metadata (persistent reference so it outlives the constructor scope)
+    auto meta = Napi::Object::New(env);
+    meta.Set("filePath", modelPath);
+    meta.Set("useGpu", useGpu);
+    meta.Set("useFlashAttn", useFlashAttn);
+    _meta = Napi::Persistent(meta);
 }
 
 WhisperContext::~WhisperContext() {
@@ -473,11 +474,12 @@ void cleanup_js_log_callback() {
     }
 }
 
-void WhisperContext::ToggleNativeLog(const Napi::CallbackInfo& info) {
+// Shared implementation for the static toggleNativeLog methods
+void toggle_native_log(const Napi::CallbackInfo& info) {
     if (info.Length() < 1) return;
 
     bool enable = whisper_utils::getBool(info[0], false);
-    
+
     if (enable) {
         cleanup_js_log_callback();
         if (info.Length() >= 2 && info[1].IsFunction()) {
@@ -491,17 +493,24 @@ void WhisperContext::ToggleNativeLog(const Napi::CallbackInfo& info) {
             );
             g_log_callback = whisper_log_callback_js;
             whisper_log_set(whisper_native_log_callback, nullptr);
+            parakeet_log_set(whisper_native_log_callback, nullptr);
         } else {
             g_log_callback = nullptr;
             whisper_log_set(nullptr, nullptr);
+            parakeet_log_set(nullptr, nullptr);
         }
         g_log_enabled = true;
     } else {
         g_log_enabled = false;
         g_log_callback = nullptr;
         whisper_log_set(nullptr, nullptr);
+        parakeet_log_set(nullptr, nullptr);
         cleanup_js_log_callback();
     }
+}
+
+void WhisperContext::ToggleNativeLog(const Napi::CallbackInfo& info) {
+    toggle_native_log(info);
 }
 
 Napi::Value WhisperContext::ModelInfo(const Napi::CallbackInfo& info) {
@@ -539,7 +548,10 @@ void WhisperContext::Init(Napi::Env env, Napi::Object& exports) {
 
 
 Napi::Value WhisperContext::GetModelInfo(const Napi::CallbackInfo& info) {
-    return _meta;
+    if (_meta.IsEmpty()) {
+        return info.Env().Null();
+    }
+    return _meta.Value();
 }
 
 Napi::Value WhisperContext::TranscribeFile(const Napi::CallbackInfo& info) {
@@ -961,45 +973,19 @@ WhisperVadContext::WhisperVadContext(const Napi::CallbackInfo& info) : Napi::Obj
     }
     _sess = std::make_shared<WhisperVadSession>(modelPath, ctx);
 
-    // Build metadata
-    _meta = Napi::Object::New(env);
-    _meta.Set("filePath", modelPath);
-    _meta.Set("useGpu", useGpu);
-    _meta.Set("nThreads", nThreads);
+    // Build metadata (persistent reference so it outlives the constructor scope)
+    auto meta = Napi::Object::New(env);
+    meta.Set("filePath", modelPath);
+    meta.Set("useGpu", useGpu);
+    meta.Set("nThreads", nThreads);
+    _meta = Napi::Persistent(meta);
 }
 
 WhisperVadContext::~WhisperVadContext() {
 }
 
 void WhisperVadContext::ToggleNativeLog(const Napi::CallbackInfo& info) {
-    if (info.Length() < 1) return;
-
-    bool enable = whisper_utils::getBool(info[0], false);
-    
-    if (enable) {
-        cleanup_js_log_callback();
-        if (info.Length() >= 2 && info[1].IsFunction()) {
-            auto callback = info[1].As<Napi::Function>();
-            g_js_log_callback = Napi::ThreadSafeFunction::New(
-                info.Env(),
-                callback,
-                "whisper_log_callback",
-                0,
-                1
-            );
-            g_log_callback = whisper_log_callback_js;
-            whisper_log_set(whisper_native_log_callback, nullptr);
-        } else {
-            g_log_callback = nullptr;
-            whisper_log_set(nullptr, nullptr);
-        }
-        g_log_enabled = true;
-    } else {
-        g_log_enabled = false;
-        g_log_callback = nullptr;
-        whisper_log_set(nullptr, nullptr);
-        cleanup_js_log_callback();
-    }
+    toggle_native_log(info);
 }
 
 Napi::Value WhisperVadContext::ModelInfo(const Napi::CallbackInfo& info) {
@@ -1034,7 +1020,10 @@ void WhisperVadContext::Init(Napi::Env env, Napi::Object& exports) {
 }
 
 Napi::Value WhisperVadContext::GetModelInfo(const Napi::CallbackInfo& info) {
-    return _meta;
+    if (_meta.IsEmpty()) {
+        return info.Env().Null();
+    }
+    return _meta.Value();
 }
 
 Napi::Value WhisperVadContext::DetectSpeechFile(const Napi::CallbackInfo& info) {

--- a/src/WhisperContext.h
+++ b/src/WhisperContext.h
@@ -32,9 +32,9 @@ private:
 
     // Internal data
     std::string _info;
-    Napi::Object _meta;
+    Napi::ObjectReference _meta;
     WhisperSessionPtr _sess = nullptr;
-    
+
     // Job tracking for cancellation
     std::atomic<int> _nextJobId{1};
     std::unordered_map<int, std::shared_ptr<std::atomic<bool>>> _cancelFlags;
@@ -67,6 +67,6 @@ private:
 
     // Internal data
     std::string _info;
-    Napi::Object _meta;
+    Napi::ObjectReference _meta;
     WhisperVadSessionPtr _sess = nullptr;
 };

--- a/src/addons.cc
+++ b/src/addons.cc
@@ -1,4 +1,5 @@
 #include "WhisperContext.h"
+#include "ParakeetContext.h"
 #include <napi.h>
 
 // Forward declaration of our cleanup function
@@ -15,6 +16,7 @@ static Napi::Value register_cleanup(const Napi::CallbackInfo &info) {
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
   WhisperContext::Init(env, exports);
   WhisperVadContext::Init(env, exports);
+  ParakeetContext::Init(env, exports);
 
   // Register our cleanup handler for module unload
   exports.Set("__registerCleanup", Napi::Function::New(env, register_cleanup));

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -29,6 +29,7 @@ void cleanup_logging() {
     g_log_callback = nullptr;
     g_log_enabled = false;
     whisper_log_set(nullptr, nullptr);
+    parakeet_log_set(nullptr, nullptr);
     cleanup_js_log_callback();
 }
 
@@ -77,6 +78,30 @@ void WhisperVadSession::lock() {
 }
 
 void WhisperVadSession::unlock() {
+    mtx.unlock();
+}
+
+// ParakeetSession implementation
+ParakeetSession::ParakeetSession(const std::string& modelPath, parakeet_context* context)
+    : path(modelPath), ctx(context) {
+}
+
+ParakeetSession::~ParakeetSession() {
+    if (ctx) {
+        parakeet_free(ctx);
+        ctx = nullptr;
+    }
+}
+
+bool ParakeetSession::isValid() const {
+    return ctx != nullptr;
+}
+
+void ParakeetSession::lock() {
+    mtx.lock();
+}
+
+void ParakeetSession::unlock() {
     mtx.unlock();
 }
 
@@ -189,6 +214,30 @@ whisper_vad_params createVadParamsFromOptions(const Napi::Object& options) {
     return params;
 }
 
+parakeet_full_params createParakeetParamsFromOptions(const Napi::Object& options) {
+    parakeet_full_params params = parakeet_full_default_params(PARAKEET_SAMPLING_GREEDY);
+    const int hardware = static_cast<int>(std::thread::hardware_concurrency());
+    params.n_threads = std::max(1, std::min(8, hardware == 0 ? 1 : hardware));
+    params.no_context = true;
+
+    auto propNames = options.GetPropertyNames();
+    for (uint32_t i = 0; i < propNames.Length(); i++) {
+        auto key = propNames.Get(i).As<Napi::String>().Utf8Value();
+        auto value = options.Get(key);
+
+        if (key == "maxThreads" && value.IsNumber()) {
+            int nThreads = value.As<Napi::Number>().Int32Value();
+            if (nThreads > 0) {
+                params.n_threads = nThreads;
+            }
+        } else if (key == "audioCtx" && value.IsNumber()) {
+            params.audio_ctx = value.As<Napi::Number>().Int32Value();
+        }
+    }
+
+    return params;
+}
+
 Napi::Object createTranscribeResult(Napi::Env env, whisper_context* ctx, const std::string& text, bool aborted) {
     auto result = Napi::Object::New(env);
     result.Set("result", text);
@@ -211,6 +260,33 @@ Napi::Object createTranscribeResult(Napi::Env env, whisper_context* ctx, const s
             segments.Set(i, segment);
         }
     }
+    result.Set("segments", segments);
+
+    return result;
+}
+
+Napi::Object createParakeetTranscribeResult(Napi::Env env, parakeet_context* ctx, bool aborted) {
+    auto result = Napi::Object::New(env);
+    result.Set("isAborted", aborted);
+    result.Set("language", "");
+
+    std::string text;
+    auto segments = Napi::Array::New(env);
+    if (ctx) {
+        int n_segments = parakeet_full_n_segments(ctx);
+        for (int i = 0; i < n_segments; i++) {
+            const char* segment_text = parakeet_full_get_segment_text(ctx, i);
+            std::string segment = segment_text ? segment_text : "";
+            text += segment;
+
+            auto segmentObj = Napi::Object::New(env);
+            segmentObj.Set("text", segment);
+            segmentObj.Set("t0", Napi::Number::New(env, static_cast<double>(parakeet_full_get_segment_t0(ctx, i) * 10))); // Convert to milliseconds
+            segmentObj.Set("t1", Napi::Number::New(env, static_cast<double>(parakeet_full_get_segment_t1(ctx, i) * 10))); // Convert to milliseconds
+            segments.Set(i, segmentObj);
+        }
+    }
+    result.Set("result", text);
     result.Set("segments", segments);
 
     return result;

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -9,11 +9,13 @@
 #include <functional>
 
 #include "whisper.h"
+#include "parakeet.h"
 
 // Forward declarations
 struct whisper_context;
 struct whisper_vad_context;
 struct whisper_full_params;
+struct parakeet_context;
 
 // Logging callback type
 typedef void (*whisper_log_callback)(const char* level, const char* text);
@@ -28,7 +30,9 @@ namespace whisper_utils {
     whisper_full_params createFullParamsFromOptions(const Napi::Object& options);
     int getNProcessorsFromOptions(const Napi::Object& options);
     whisper_vad_params createVadParamsFromOptions(const Napi::Object& options);
+    parakeet_full_params createParakeetParamsFromOptions(const Napi::Object& options);
     Napi::Object createTranscribeResult(Napi::Env env, whisper_context* ctx, const std::string& text, bool aborted = false);
+    Napi::Object createParakeetTranscribeResult(Napi::Env env, parakeet_context* ctx, bool aborted = false);
     Napi::Object createVadResult(Napi::Env env, bool hasSpeech, float speechProbability, const std::vector<std::pair<int64_t, int64_t>>& segments);
 
     std::vector<float> convertAudioBufferToFloat(Napi::ArrayBuffer& buffer);
@@ -69,6 +73,23 @@ public:
 
 using WhisperVadSessionPtr = std::shared_ptr<WhisperVadSession>;
 
+// Parakeet Session management
+class ParakeetSession {
+public:
+    std::string path;
+    parakeet_context* ctx;
+    std::mutex mtx;
+
+    ParakeetSession(const std::string& modelPath, parakeet_context* context);
+    ~ParakeetSession();
+
+    bool isValid() const;
+    void lock();
+    void unlock();
+};
+
+using ParakeetSessionPtr = std::shared_ptr<ParakeetSession>;
+
 // Logging utilities
 extern whisper_log_callback g_log_callback;
 extern bool g_log_enabled;
@@ -77,3 +98,4 @@ void whisper_log_callback_default(const char* level, const char* text);
 void setup_logging();
 void cleanup_logging();
 void cleanup_js_log_callback();  // Cleanup JavaScript logging callback
+void toggle_native_log(const Napi::CallbackInfo& info);  // Shared static toggleNativeLog implementation

--- a/src/wasm/emscripten.cpp
+++ b/src/wasm/emscripten.cpp
@@ -1,4 +1,5 @@
 #include "whisper.h"
+#include "parakeet.h"
 
 #include <emscripten/bind.h>
 #include <emscripten/val.h>
@@ -52,10 +53,27 @@ struct VadSession {
     }
 };
 
+struct ParakeetSession {
+    std::string path;
+    parakeet_context * ctx = nullptr;
+    std::mutex mutex;
+
+    ParakeetSession(std::string model_path, parakeet_context * context)
+        : path(std::move(model_path)), ctx(context) {}
+
+    ~ParakeetSession() {
+        if (ctx) {
+            parakeet_free(ctx);
+            ctx = nullptr;
+        }
+    }
+};
+
 std::mutex g_sessions_mutex;
 int g_next_session_id = 1;
 std::map<int, std::unique_ptr<WhisperSession>> g_whisper_sessions;
 std::map<int, std::unique_ptr<VadSession>> g_vad_sessions;
+std::map<int, std::unique_ptr<ParakeetSession>> g_parakeet_sessions;
 
 val ok() {
     val result = val::object();
@@ -163,6 +181,15 @@ VadSession * get_vad_session(int id) {
     return it->second.get();
 }
 
+ParakeetSession * get_parakeet_session(int id) {
+    std::lock_guard<std::mutex> lock(g_sessions_mutex);
+    auto it = g_parakeet_sessions.find(id);
+    if (it == g_parakeet_sessions.end()) {
+        return nullptr;
+    }
+    return it->second.get();
+}
+
 whisper_full_params create_full_params(const val & options) {
     whisper_full_params params = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
 
@@ -200,6 +227,45 @@ whisper_vad_params create_vad_params(const val & options) {
     params.samples_overlap = get_float(options, "samplesOverlap", params.samples_overlap);
 
     return params;
+}
+
+parakeet_full_params create_parakeet_full_params(const val & options) {
+    parakeet_full_params params = parakeet_full_default_params(PARAKEET_SAMPLING_GREEDY);
+
+    params.n_threads = get_int(options, "maxThreads", default_thread_count());
+    params.audio_ctx = get_int(options, "audioCtx", params.audio_ctx);
+    params.no_context = true;
+
+    params.n_threads = clamp_thread_count(params.n_threads);
+
+    return params;
+}
+
+val create_parakeet_transcribe_result(parakeet_context * ctx, bool aborted) {
+    val result = ok();
+    result.set("isAborted", aborted);
+    result.set("language", "");
+
+    std::string text;
+    val segments = val::array();
+    if (ctx) {
+        const int n_segments = parakeet_full_n_segments(ctx);
+        for (int i = 0; i < n_segments; ++i) {
+            const char * segment_text = parakeet_full_get_segment_text(ctx, i);
+            std::string segment = segment_text ? segment_text : "";
+            text += segment;
+
+            val segment_obj = val::object();
+            segment_obj.set("text", segment);
+            segment_obj.set("t0", static_cast<double>(parakeet_full_get_segment_t0(ctx, i) * 10));
+            segment_obj.set("t1", static_cast<double>(parakeet_full_get_segment_t1(ctx, i) * 10));
+            segments.call<void>("push", segment_obj);
+        }
+    }
+    result.set("result", text);
+    result.set("segments", segments);
+
+    return result;
 }
 
 val create_segment(whisper_context * ctx, int index, bool tdrz_enable) {
@@ -357,6 +423,34 @@ val init_vad(const std::string & model_path, bool use_gpu, int n_threads) {
     return result;
 }
 
+val init_parakeet(const std::string & model_path, bool use_gpu) {
+    if (model_path.empty()) {
+        return error_result("Model path is required");
+    }
+
+    parakeet_context_params params = parakeet_context_default_params();
+    params.use_gpu = use_gpu;
+    params.gpu_device = 0;
+
+    parakeet_context * ctx = parakeet_init_from_file_with_params(model_path.c_str(), params);
+    if (!ctx) {
+        return error_result("Failed to initialize parakeet context");
+    }
+
+    int id = 0;
+    {
+        std::lock_guard<std::mutex> lock(g_sessions_mutex);
+        id = g_next_session_id++;
+        g_parakeet_sessions[id] = std::make_unique<ParakeetSession>(model_path, ctx);
+    }
+
+    val result = ok();
+    result.set("id", id);
+    result.set("filePath", model_path);
+    result.set("useGpu", use_gpu);
+    return result;
+}
+
 void free_whisper(int id) {
     std::lock_guard<std::mutex> lock(g_sessions_mutex);
     g_whisper_sessions.erase(id);
@@ -365,6 +459,11 @@ void free_whisper(int id) {
 void free_vad(int id) {
     std::lock_guard<std::mutex> lock(g_sessions_mutex);
     g_vad_sessions.erase(id);
+}
+
+void free_parakeet(int id) {
+    std::lock_guard<std::mutex> lock(g_sessions_mutex);
+    g_parakeet_sessions.erase(id);
 }
 
 val transcribe(int id, const val & audio, const val & options) {
@@ -435,6 +534,38 @@ val transcribe(int id, const val & audio, const val & options) {
     }
 
     return create_transcribe_result(session->ctx, text.str(), false, params.tdrz_enable);
+}
+
+val transcribe_parakeet(int id, const val & audio, const val & options) {
+    ParakeetSession * session = get_parakeet_session(id);
+    if (!session || !session->ctx) {
+        return error_result("Invalid parakeet context");
+    }
+
+    std::vector<float> pcmf32 = copy_float32_array(audio);
+    if (pcmf32.empty()) {
+        return create_parakeet_transcribe_result(nullptr, false);
+    }
+
+    std::lock_guard<std::mutex> lock(session->mutex);
+    if (!session->ctx) {
+        return error_result("Parakeet context was destroyed");
+    }
+
+    parakeet_full_params params = create_parakeet_full_params(options);
+
+    const int result = parakeet_full(
+        session->ctx,
+        params,
+        pcmf32.data(),
+        static_cast<int>(pcmf32.size())
+    );
+
+    if (result != 0) {
+        return error_result("Parakeet transcription failed: " + std::to_string(result));
+    }
+
+    return create_parakeet_transcribe_result(session->ctx, false);
 }
 
 val detect_speech(int id, const val & audio, const val & options) {
@@ -589,6 +720,10 @@ EMSCRIPTEN_BINDINGS(whisper_node_wasm) {
     emscripten::function("__wasm_init_vad", &init_vad);
     emscripten::function("__wasm_free_vad", &free_vad);
     emscripten::function("__wasm_detect_speech", &detect_speech);
+
+    emscripten::function("__wasm_init_parakeet", &init_parakeet);
+    emscripten::function("__wasm_free_parakeet", &free_parakeet);
+    emscripten::function("__wasm_transcribe_parakeet", &transcribe_parakeet);
 
     emscripten::function("__wasm_system_info", &system_info);
     emscripten::function("__wasm_webgpu_enabled", &webgpu_enabled);

--- a/test/parakeet.test.ts
+++ b/test/parakeet.test.ts
@@ -1,0 +1,184 @@
+import fs from 'fs'
+import path from 'path'
+import { initParakeet } from '../lib/index'
+
+// Test configuration
+const TEST_TIMEOUT = 60000 // 60 seconds timeout for model loading
+const SAMPLE_AUDIO_PATH = path.join(__dirname, '../whisper.cpp/samples/jfk.wav')
+
+// Helper function to create test audio data (16-bit PCM, mono, 16kHz)
+function createTestAudioBuffer(durationMs = 1000, frequency = 440) {
+  const sampleRate = 16000
+  const samples = Math.floor((durationMs * sampleRate) / 1000)
+  const buffer = new ArrayBuffer(samples * 2) // 16-bit = 2 bytes per sample
+  const view = new Int16Array(buffer)
+
+  for (let i = 0; i < samples; i += 1) {
+    // Generate sine wave
+    const t = i / sampleRate
+    const amplitude = 16000 // Scale to 16-bit range
+    view[i] = Math.sin(2 * Math.PI * frequency * t) * amplitude
+  }
+
+  return buffer
+}
+
+// Helper function to load WAV file and convert to ArrayBuffer
+function loadWavFile(filePath: string) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Audio file not found: ${filePath}`)
+  }
+
+  const buffer = fs.readFileSync(filePath)
+
+  // Simple WAV file parsing - skip header and get audio data
+  // WAV header is typically 44 bytes
+  const headerSize = 44
+  const audioData = buffer.slice(headerSize)
+
+  // Convert to ArrayBuffer
+  return audioData.buffer.slice(
+    audioData.byteOffset,
+    audioData.byteOffset + audioData.byteLength,
+  )
+}
+
+describe('Parakeet transcription', () => {
+  const modelPath = path.join(
+    __dirname,
+    '../whisper.cpp/models/ggml-parakeet-tdt-0.6b-v3-q4_0.bin',
+  )
+
+  test(
+    'should load parakeet model',
+    async () => {
+      const context = await initParakeet({
+        filePath: modelPath,
+        useGpu: false,
+      })
+
+      expect(context).toBeDefined()
+
+      await context.release()
+    },
+    TEST_TIMEOUT,
+  )
+
+  test(
+    'should transcribe JFK audio sample',
+    async () => {
+      const audioBuffer = loadWavFile(SAMPLE_AUDIO_PATH)
+
+      const context = await initParakeet({
+        filePath: modelPath,
+        useGpu: false,
+      })
+
+      const { promise } = context.transcribeData(audioBuffer, {
+        maxThreads: 4,
+      })
+
+      const result = await promise
+
+      expect(result).toBeDefined()
+      expect(typeof result.result).toBe('string')
+      expect(result.result.length).toBeGreaterThan(0)
+      expect(Array.isArray(result.segments)).toBe(true)
+      expect(result.isAborted).toBe(false)
+
+      // JFK sample should contain recognizable words
+      const lowerText = result.result.toLowerCase()
+      expect(lowerText).toMatch(/ask|not|what|your|country|can|do|for|you/)
+
+      console.log('Transcription result:', result.result)
+
+      await context.release()
+    },
+    TEST_TIMEOUT,
+  )
+
+  test(
+    'should transcribe audio file path',
+    async () => {
+      const context = await initParakeet({
+        filePath: modelPath,
+        useGpu: false,
+      })
+
+      const { promise } = context.transcribeFile(SAMPLE_AUDIO_PATH, {
+        maxThreads: 4,
+      })
+
+      const result = await promise
+
+      expect(result).toBeDefined()
+      expect(typeof result.result).toBe('string')
+      expect(result.result.length).toBeGreaterThan(0)
+
+      await context.release()
+    },
+    TEST_TIMEOUT,
+  )
+
+  test(
+    'should return correct API structure with stop and promise',
+    async () => {
+      const context = await initParakeet({
+        filePath: modelPath,
+        useGpu: false,
+      })
+
+      const audioBuffer = createTestAudioBuffer(100, 440) // Very short audio
+
+      const result = context.transcribeData(audioBuffer, {
+        maxThreads: 2,
+      })
+
+      // Verify the API structure matches whisper.rn standard
+      expect(result).toBeDefined()
+      expect(typeof result).toBe('object')
+      expect(typeof result.stop).toBe('function')
+      expect(typeof result.promise).toBe('object')
+      expect(typeof result.promise.then).toBe('function')
+      expect(result.promise.constructor.name).toBe('Promise')
+
+      // Wait for transcription to complete
+      const transcriptionResult = await result.promise
+
+      expect(transcriptionResult).toBeDefined()
+      expect(typeof transcriptionResult.result).toBe('string')
+      expect(Array.isArray(transcriptionResult.segments)).toBe(true)
+      expect(typeof transcriptionResult.isAborted).toBe('boolean')
+
+      await context.release()
+    },
+    TEST_TIMEOUT,
+  )
+
+  test('should handle invalid audio data', async () => {
+    const invalidBuffer = new ArrayBuffer(0) // Empty buffer
+
+    const context = await initParakeet({
+      filePath: modelPath,
+      useGpu: false,
+    })
+
+    const { promise } = context.transcribeData(invalidBuffer)
+    const result = await promise
+
+    expect(result).toEqual({
+      isAborted: false,
+      language: '',
+      result: '',
+      segments: [],
+    })
+
+    await context.release()
+  }, TEST_TIMEOUT)
+
+  test('should handle model loading errors', async () => {
+    const invalidModelPath = 'nonexistent/model.bin'
+
+    await expect(initParakeet({ filePath: invalidModelPath })).rejects.toThrow()
+  })
+})


### PR DESCRIPTION
Syncs the Parakeet API from whisper.rn (mybigday/whisper.rn@ecf732e31c68ab0bf0abe1b7ebf3b951ebda563b, #332 there) so whisper.node exposes the same `initParakeet` / `ParakeetContext` surface. Both repos already point at the same whisper.cpp fork commit containing `parakeet.{h,cpp}`, so no submodule change is needed.

## Native (N-API)

- New `src/ParakeetContext.{h,cpp}`: `transcribe` / `transcribeFile` / `transcribeData` return `{ stop, promise }`, plus `release()`, `getModelInfo()`, and static `toggleNativeLog` / `loadModelInfo`
- Transcribe options are `maxThreads` and `audioCtx` (Whisper-only options don't apply); `no_context` is enabled like whisper.rn
- `stop()` is wired into the ggml abort callback, so it interrupts computation mid-run and resolves with `isAborted: true` (context stays reusable afterward)
- Segment `t0`/`t1` are converted to milliseconds, matching the existing whisper.node convention (whisper.rn returns raw centiseconds)
- Parakeet logs route through the shared native log toggle (`parakeet_log_set`)
- CMake links the `parakeet` library target for native and WASM builds

## Browser WASM

- `__wasm_init_parakeet` / `__wasm_free_parakeet` / `__wasm_transcribe_parakeet` embind bindings in `src/wasm/emscripten.cpp`
- `ParakeetContext` in `@fugood/node-whisper-wasm` with both direct and worker-proxy variants, worker dispatch cases, and typings; clear error when an older WASM build lacks the bindings
- WASM artifacts rebuilt via `build-wasm-docker` and verified to contain the new bindings (not committed, as usual)

## Fixes

- `getModelInfo()` on all context classes was returning a `Napi::Object` stored past its handle scope (`WhisperContext.getModelInfo()` threw `Symbol.prototype.toString requires that 'this' be a Symbol`, VAD meta silently dropped keys). Meta objects are now held via `Napi::Persistent` references.

## Tests / docs

- `test/parakeet.test.ts` (6 tests) against the real `ggml-parakeet-tdt-0.6b-v3-q4_0.bin`; model added to `download-test-models.js`
- Node example (`examples/parakeetTranscription.js`), optional Parakeet section in the WASM smoke page, README sections for native and browser usage

## Test plan

- `npx jest` — 3 suites, 21 tests pass (whisper, VAD, parakeet); JFK sample transcribes correctly with Parakeet in ~390 ms on CPU
- Manually verified abort semantics (`stop()` → `{ isAborted: true }`, context reusable) and repeated transcriptions on one context return identical results
- Native build clean via `cmake-js`; WASM build clean via emsdk docker image

Note: published platform packages need a rebuild/republish before `initParakeet` works from prebuilt binaries; until then it throws a clear "please update the platform package" error.